### PR TITLE
event stream max offset obtained using offset query

### DIFF
--- a/kestrel-http-event-streams/src/main/kotlin/com/dreweaster/ddd/kestrel/infrastructure/http/eventstream/consumer/reporting/BoundedContextHttpEventStreamSourceReporter.kt
+++ b/kestrel-http-event-streams/src/main/kotlin/com/dreweaster/ddd/kestrel/infrastructure/http/eventstream/consumer/reporting/BoundedContextHttpEventStreamSourceReporter.kt
@@ -25,6 +25,12 @@ interface BoundedContextHttpEventStreamSourceProbe {
 
     fun finishedFetchingOffset(ex: Throwable)
 
+    fun startedFetchingMaxOffset()
+
+    fun finishedFetchingMaxOffset(offset: Long)
+
+    fun finishedFetchingMaxOffset(ex: Throwable)
+
     fun startedSavingOffset()
 
     fun finishedSavingOffset(offset: Long)
@@ -76,6 +82,18 @@ class ReportingContext(subscriptionName: String, reporters: List<BoundedContextH
 
     override fun finishedFetchingOffset(ex: Throwable) {
         probes.forEach { it.finishedFetchingOffset(ex) }
+    }
+
+    override fun startedFetchingMaxOffset() {
+        probes.forEach { it.startedFetchingMaxOffset() }
+    }
+
+    override fun finishedFetchingMaxOffset(offset: Long) {
+        probes.forEach { it.finishedFetchingMaxOffset(offset) }
+    }
+
+    override fun finishedFetchingMaxOffset(ex: Throwable) {
+        probes.forEach { it.finishedFetchingMaxOffset(ex) }
     }
 
     override fun startedSavingOffset() {
@@ -140,6 +158,18 @@ object ConsoleReporter : BoundedContextHttpEventStreamSourceReporter {
         }
 
         override fun finishedFetchingOffset(ex: Throwable) {
+
+        }
+
+        override fun startedFetchingMaxOffset() {
+
+        }
+
+        override fun finishedFetchingMaxOffset(offset: Long) {
+
+        }
+
+        override fun finishedFetchingMaxOffset(ex: Throwable) {
 
         }
 


### PR DESCRIPTION
Identified a performance issue when initialising an event stream consumer for the first time on an event stream with large volumes (5m).

If the consumer didn't find the last processed offset, it queried for the events using the timestamp query. The domain event table does not have an index on event timestamp (correctly so IMO) and so the query was doing a table scan and timing out after 50 seconds.

This has been changed so the event stream max offset is obtained first using the offset query instead of timestamp query.