### PR TITLE
improve variance for API consumers

### DIFF
--- a/kestrel-json/src/main/kotlin/com/dreweaster/ddd/kestrel/infrastructure/driven/backend/mapper/json/JsonMappingContext.kt
+++ b/kestrel-json/src/main/kotlin/com/dreweaster/ddd/kestrel/infrastructure/driven/backend/mapper/json/JsonMappingContext.kt
@@ -1,30 +1,29 @@
 package com.dreweaster.ddd.kestrel.infrastructure.driven.backend.mapper.json
 
-import com.dreweaster.ddd.kestrel.application.PersistableMappingContext
 import com.dreweaster.ddd.kestrel.application.MappingException
+import com.dreweaster.ddd.kestrel.application.PersistableMappingContext
 import com.dreweaster.ddd.kestrel.application.PersistableSerialisationResult
 import com.dreweaster.ddd.kestrel.application.SerialisationContentType
 import com.dreweaster.ddd.kestrel.domain.Persistable
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import java.io.IOException
-import kotlin.reflect.KClass
 
-interface JsonMapperBuilder<Data : Persistable> {
+interface JsonMapperBuilder<in Data : Persistable> {
 
     fun migrateFormat(migration: ((ObjectNode) -> ObjectNode)): JsonMapperBuilder<Data>
 
     fun migrateClassName(className: String): JsonMapperBuilder<Data>
 
-    fun mappingFunctions(serialiseFunction: ((Data) ->  ObjectNode), deserialiseFunction: ((ObjectNode) -> Data))
+    fun mappingFunctions(serialiseFunction: ((@UnsafeVariance Data) -> ObjectNode), deserialiseFunction: ((ObjectNode) -> Data))
 }
 
-interface JsonMapperBuilderFactory<Data : Persistable> {
+interface JsonMapperBuilderFactory<in Data : Persistable> {
 
     fun create(initialClassName: String): JsonMapperBuilder<Data>
 }
 
-interface JsonMapper<Data : Persistable> {
+interface JsonMapper<out Data : Persistable> {
 
     fun configure(factory: JsonMapperBuilderFactory<Data>)
 }

--- a/kestrel-json/src/test/kotlin/com/dreweaster/ddd/kestrel/infrastructure/driven/backend/mapper/json/JsonMappingContextTests.kt
+++ b/kestrel-json/src/test/kotlin/com/dreweaster/ddd/kestrel/infrastructure/driven/backend/mapper/json/JsonMappingContextTests.kt
@@ -1,8 +1,8 @@
 package com.dreweaster.ddd.kestrel.infrastructure.driven.backend.mapper.json
 
-import com.dreweaster.ddd.kestrel.domain.Persistable
 import com.dreweaster.ddd.kestrel.domain.DomainEvent
 import com.dreweaster.ddd.kestrel.domain.DomainEventTag
+import com.dreweaster.ddd.kestrel.domain.Persistable
 import com.dreweaster.ddd.kestrel.util.json.*
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
@@ -11,13 +11,13 @@ import io.kotest.matchers.shouldBe
 
 class JsonMappingContextTests : FeatureSpec() {
 
-    val objectMapper = ObjectMapper()
+    private val objectMapper = ObjectMapper()
 
     init {
         feature("A JsonMappingContext can deserialise different versions of conceptual aggregate data with a complex migration history") {
 
             val mappers: List<JsonMapper<Persistable>> =
-                    listOf(EventWithComplexMigrationHistoryMapper()) as List<JsonMapper<Persistable>>
+                listOf(EventWithComplexMigrationHistoryMapper())
 
             val context = JsonMappingContext(mappers)
 


### PR DESCRIPTION
This avoids having to do an unsafe cast to `JsonMapper<Persistable>` in the consumer code (see the test for an example).